### PR TITLE
Initialize Session Stats so it won't crash the first time

### DIFF
--- a/src/flexsea_cmd_session_stats.c
+++ b/src/flexsea_cmd_session_stats.c
@@ -61,7 +61,7 @@ void initSessionStats(void)
     {
         sessionStats.duration[i] = 0;
         sessionStats.energy[i] = 0;
-        sessionStats.status[i] = 0;
+        sessionStats.status[i] = 2;
     }
 }
 


### PR DESCRIPTION
Plan can't interpret a status of 0 so it crashes the first time. Initialize to 2 (i.e. PROBLEM state)